### PR TITLE
Firefox: use addons.mozilla.org URL for feedback

### DIFF
--- a/src_fx/popup.html
+++ b/src_fx/popup.html
@@ -38,7 +38,7 @@
                     <input id="hideShortVideoInput" type="checkbox">
                     <label for="hideShortVideoInput" class="cantSelectable">ショート動画を非表示</label>
                 </div>
-                <div id="warn" class="settings_column cantSelectable"><div id="warn_col" class="warn_msg_cmn">Warning!</div><div id="warn_msg" class="warn_msg_cmn"> May not work properly!</div><br>"<a id="warn_fb" class="warn_msg_cmn" href="https://chrome.google.com/webstore/detail/youtube-shorts-block/jiaopdjbehhjgokpphdfgmapkobbnmjp" target="_blank">フィードバック</a>"<div id="warn_or" class="warn_msg_cmn">または</div>"<a id="warn_pr" class="warn_msg_cmn" href="https://github.com/doma-itachi/Youtube-shorts-block" target="_blank">プルリクエスト</a>"</div>
+                <div id="warn" class="settings_column cantSelectable"><div id="warn_col" class="warn_msg_cmn">Warning!</div><div id="warn_msg" class="warn_msg_cmn"> May not work properly!</div><br>"<a id="warn_fb" class="warn_msg_cmn" href="https://addons.mozilla.org/firefox/addon/youtube-shorts-block/" target="_blank">フィードバック</a>"<div id="warn_or" class="warn_msg_cmn">または</div>"<a id="warn_pr" class="warn_msg_cmn" href="https://github.com/doma-itachi/Youtube-shorts-block" target="_blank">プルリクエスト</a>"</div>
             </div>
         </div>
         <script src="popup.js"></script>


### PR DESCRIPTION
Small bugfix for the [Firefox version of the extension](https://addons.mozilla.org/firefox/addon/youtube-shorts-block/). Details are in the commit message.

Thank you for developing and maintaining this extension.