### PR TITLE
Fixes #52 - Falsely matching video-id if channel-id ends in "shorts"

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ class Extension {
     }
 
     static convertToVideoURL(url: string): string | undefined {
-        const result = url.match(/shorts\/(.*)\/?/);
+        const result = url.match(/shorts\/(.{11})\/?/);
         if (result) {
             return `https://www.youtube.com/watch?v=${result[1]}`;
         }


### PR DESCRIPTION
Fixes #52 

As described in the issue, the plugin tries to match a video-id if a channel-id ends in "shorts". 
This then led to an incorrect redirect.

This is fixed by constraining the regular expression to only produce matches if the matched suffix is 11 digits long.
Refer to [this](https://stackoverflow.com/questions/6180138/whats-the-maximum-length-of-a-youtube-video-id) SO-post for a reference for the value 11.

Tested cases:

- `https://www.youtube.com/shorts/$video_id`
--> Passes
- `https://youtu.be/$video_id`
--> Passes
- `https://www.youtube.com/$channel_id + "shorts"/videos`
--> Passes